### PR TITLE
Bug:Hero Banner setting

### DIFF
--- a/app/content/about.tsx
+++ b/app/content/about.tsx
@@ -18,6 +18,7 @@ function About() {
   return (
     <>
       <Box
+        position="relative"
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -52,7 +53,7 @@ function About() {
             alignItems: 'center',
             justifyContent: 'center',
             position: 'absolute',
-            left: { lg: '2%' },
+            left: { lg: '1rem' },
             gap: { xs: '20px', lg: '0px' },
           }}
         >


### PR DESCRIPTION
close #9 

- แก้กล่อง Box detail ให้ไม่เกินขอบ container

<img width="974" height="604" alt="Screenshot 2568-12-11 at 13 52 29" src="https://github.com/user-attachments/assets/5c49010d-1bc7-45ee-9555-95c8bf898774" />
