### PR TITLE
Bug:Desktop & Mobile set some gap left and right

### DIFF
--- a/app/content/about-pineapple.tsx
+++ b/app/content/about-pineapple.tsx
@@ -5,22 +5,23 @@ import image from '../assets/image1.png'
 
 function AboutPineApple() {
   const imageStyle: CSSProperties = {
-    height: '620px',
+    aspectRatio:"auto",
     position: 'relative',
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'center',
+    objectFit:"cover"
   }
 
   return (
     <>
       <Box
-        sx={{
+         sx={{
           display: 'flex',
           flexDirection: { xs: 'column', lg: 'row' },
           justifyContent: 'center',
           gap: '60px',
           alignItems: 'center',
-          margin: { xs: '30px', lg: '0px' },
+          margin: "30px",
           minHeight: '800px',
         }}>
         {/* หัวข้อ */}
@@ -47,15 +48,13 @@ function AboutPineApple() {
             <Image
               style={imageStyle}
               src={image}
-              width={728}
-              height={620}
               alt='house'
             />
           </Box>
 
           {/* ข้อความ */}
           <Box
-            width={433}
+            maxWidth={433}
             height={620}
             padding={{ xs: '50px', md: '10px', lg: '50px' }}
             color={'white'}


### PR DESCRIPTION
close #12 

- เพิ่ม Gap ทั้งด้านซ้าย-ขวาให้เท่ากัน
- เมื่อลดขนาดจอแล้ว รูปภาพโดนบีบ ทั้ง Desktop และ Mobile

<img width="974" height="666" alt="Screenshot 2568-12-11 at 16 17 57" src="https://github.com/user-attachments/assets/03009cce-dead-41d2-8e2f-b40f0c4479d5" />

<img width="759" height="636" alt="Screenshot 2568-12-11 at 16 18 50" src="https://github.com/user-attachments/assets/5fe8d14b-cb9e-4ff0-b6c4-78124ca40747" />
